### PR TITLE
🐛[Fix]: CommonType 영향 받는 UserDefaultsManager struct 객체 수정

### DIFF
--- a/Tublock/Tublock/Sources/Service/UserDefaultsManager.swift
+++ b/Tublock/Tublock/Sources/Service/UserDefaultsManager.swift
@@ -27,6 +27,6 @@ struct UserDefaultsManager {
     @UserDefaultsWrapper(key: CommonType.MAXIMUM_TIME, defaultValue: (0,0))
     static var time: BlockTime
     
-    @UserDefaultsWrapper(key: CommonType.NOTIFICATION_MESSEAGE, defaultValue: "")
+    @UserDefaultsWrapper(key: CommonType.NOTIFICATION_CONTENTS, defaultValue: "")
     static var message: String
 }


### PR DESCRIPTION
String Key 로 사용되는 CommonType class 객체의 `NOTIFICATION_MESSAGE` 를 `NOTIFICATION_CONTENTS` 로 변경함에 따라서 
같이 변경되어야하는 UserDefaultsManager 객체를 수정하지않았어요 
다음에는 잘 확인할게요 번거롭게해서 죄송해요