### PR TITLE
🐛[Fix]: 피커뷰 레이아웃 수정 #53

### DIFF
--- a/Tublock/Tublock/Sources/MainScene/Components/SetMaximum/View/TimePickerModalViewController.swift
+++ b/Tublock/Tublock/Sources/MainScene/Components/SetMaximum/View/TimePickerModalViewController.swift
@@ -140,13 +140,13 @@ extension TimePickerModalViewController {
         
         _hoursLabel.snp.makeConstraints { make in
             make.left.equalTo(_timePickerView).inset(100)
-            make.centerY.centerY.equalTo(_timePickerView)
+            make.centerY.equalTo(_timePickerView)
             make.height.equalTo(20)
         }
         
         _minutesLabel.snp.makeConstraints { make in
             make.right.equalTo(_timePickerView).inset(20)
-            make.centerY.centerY.equalTo(_timePickerView)
+            make.centerY.equalTo(_timePickerView)
             make.height.equalTo(20)
         }
         


### PR DESCRIPTION
## 구현사항
중복되어있던 `centerY` 하나 삭제했습니다
```swift
        _hoursLabel.snp.makeConstraints { make in
            make.left.equalTo(_timePickerView).inset(100)
            make.centerY.equalTo(_timePickerView)
            make.height.equalTo(20)
        }
        
        _minutesLabel.snp.makeConstraints { make in
            make.right.equalTo(_timePickerView).inset(20)
            make.centerY.equalTo(_timePickerView)
            make.height.equalTo(20)
        }
```

## 리뷰어 참고사항
아직 이것 외엔 수정하지 않았습니당
기기별로 달라보일 것 같은 UI 수정사항은 추후에 한번에 작업할게요!