### PR TITLE
🐛[Fix]: SE2 기기에서 라벨 안보이는 문제

### DIFF
--- a/Tublock/Tublock/Sources/MainScene/Components/SetMaximum/View/TimePickerModalViewController.swift
+++ b/Tublock/Tublock/Sources/MainScene/Components/SetMaximum/View/TimePickerModalViewController.swift
@@ -218,8 +218,7 @@ extension TimePickerModalViewController {
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let cancelAction = UIAlertAction(title: "Wait".localized, style: .default)
         let okAction = UIAlertAction(title: "Confirm".localized, style: .destructive) { [weak self] _ in
-            // TODO: UserDefaultsManager 에 selectedTime 저장하는 로직
-            //UserDefaultsManager.time = (self?.selectedTime) ?? (0, 0) -> 불가능
+            UserDefaultsManager.time = self?.selectedTime ?? (0, 0)
             self?.dismiss(animated: true, completion: nil)
         }
         


### PR DESCRIPTION
Close #56

## 구현 된 UI
<img width="300px" alt="스샷" src="https://user-images.githubusercontent.com/108422901/236807020-aff5bfe7-d5d3-47a2-acbb-07209fbdf684.jpeg" />

## 구현사항
`NSAttributedString`를 반환하는 `getFormattedTime()` 메서드에서 라벨 텍스트 컬러 수정

---

> [수정 확인헸어요 ! 다른 기종이나 기존에는 왜 잘 보였던걸까요 ? 🧐 버그 원인 공유 부탁해요 !](https://github.com/doyeonjeong/Tublock/pull/57#pullrequestreview-1416591971)

## 버그 원인
`NSAttributedString.Key.foregroundColor`의 값을 지정하지 않아서 발생한 문제였어요

[공식 문서](https://developer.apple.com/documentation/foundation/nsattributedstring/key/1533563-foregroundcolor)에 따르면 `foregroundColor`를 지정하지 않았을 때 black이 기본 색상으로 표시된다고 하는데요

<img width="944" alt="스크린샷 2023-05-08 오후 8 11 52" src="https://user-images.githubusercontent.com/108422901/236809420-abb6e14f-f127-403c-be48-690be3154d92.png">

현재로서는 SE2 기종의 경우 `foregroundColor`의 값이 `white`로 설정되어있던게 아닐까? 라고 추측할 수 밖에 없는 상황인 것 같아요..!

왜냐하면 시뮬레이터에는 `iPhone SE (3rd generation)`부터 볼 수 있고,
`foregroundColor`를 지정하지 않고 확인해봐도 오류는 보이지 않기 때문입니다.

<img width="300px" alt="스샷" src="https://user-images.githubusercontent.com/108422901/236810458-3f632d3b-b7d2-40e0-a5ef-cab3f1d9069d.png" />


따라서 해당 오류는 특정 기기에서만 볼 수 있었던 문제이지 않나 싶습니다!
